### PR TITLE
Percentage rule: properly handle null identifier

### DIFF
--- a/src/Rules/PercentageRule.php
+++ b/src/Rules/PercentageRule.php
@@ -43,6 +43,10 @@ class PercentageRule extends RuleAbstract {
    */
   public function canAccess( $identifier = null ) {
 
+    if ( $identifier === null ) {
+      return false;
+    }
+
     return ( $this->_getBucket( $identifier ) <= $this->_percentage );
 
   } // canAccess

--- a/tests/unit/Rules/PercentageRuleTest.php
+++ b/tests/unit/Rules/PercentageRuleTest.php
@@ -40,6 +40,17 @@ class PercentageRuleTest extends BaseTest {
   /**
    * @test
    */
+  public function canAccessFalseNullIdentifier() {
+
+    $this->_getRule( 100, 'feature' );
+
+    $this->assertFalse( $this->_rule->canAccess( null ) );
+
+  } // canAccessFalseNullIdentifier
+
+  /**
+   * @test
+   */
   public function invalidPercentage() {
 
     $this->expectException( \InvalidArgumentException::class );


### PR DESCRIPTION
@markdunphy 
@eugenebond 
@amy 
@be-dmitry 

@be-dmitry and I talked about this a bit, and we both ended up agreeing that even if at 100 percent, a percentage rule provided a null identifier will return false.

We think that there could be some further discussion on the actual behavior of sending a percentage rule a null identifier. While it doesn't really make sense to send null to a percentage rule as the identifier, it is a completely valid use-case to be sent in from the library because of the multiple-rule-per-feature capability. Ex. you want to expose 50% of the userbase to a feature, but you also want 100% of users to be able to see it starting at a specific date or time.

Dmitry suggested we can think about throwing an exception just to make this clear, and catch it somewhere else, which I think we should think about but right now I'd like to finish up the implementation into network.