### PR TITLE
New rule: percentage rule for dice roll (random) access

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Right now it comes with the following rules (though it's easy to add your own to
 <tr><td>IdentifierRule</td><td>Identifiers (ex. user ids) that are in the given list provided by config are granted access.</td></tr>
 <tr><td>AuthenticatedPercentageRule</td><td>Primarily for a/b testing, allows a feature to be turned on for x percentage of users, which is consistently determined automatically by the given user identifier. For this rule, "authenticated" is meant to represent that the rule should only be applied to an identifier that is marked as "authenticated" (see "Basic Usage" example below.)</td></tr>
 <tr><td>AnonymousPercentageRule</td><td>Exactly the same as AuthenticatedPercentageRule, except this rule type only applies to identifiers that are marked as "anonymous."</td></tr>
+<tr><td>RandomPercentageRule</td><td>This rule creates a new, random identifier every time access to the rule is checked. This rule can be used for action you want to occur x% of the time, not based on any actual identifier.</td></tr>
 <tr><td>BetweenTimesRule</td><td>grants access if the current date/time is between two specified date/times</td></tr>
 <tr><td>StartTimeRule</td><td>grants access beginning at a specified date/time</td></tr>
 <tr><td>EndTimeRule</td><td>grants access up until a specified end date/time</td></tr>

--- a/src/RuleFactory.php
+++ b/src/RuleFactory.php
@@ -12,6 +12,7 @@ use Behance\NBD\Gatekeeper\Rules\BinaryRule;
 use Behance\NBD\Gatekeeper\Rules\EndTimeRule;
 use Behance\NBD\Gatekeeper\Rules\IdentifierRule;
 use Behance\NBD\Gatekeeper\Rules\PercentageRule;
+use Behance\NBD\Gatekeeper\Rules\RandomPercentageRule;
 use Behance\NBD\Gatekeeper\Rules\StartTimeRule;
 
 class RuleFactory {
@@ -79,6 +80,17 @@ class RuleFactory {
             $feature
         );
 
+      case RandomPercentageRule::RULE_NAME:
+
+        if ( $feature == null ) {
+          throw new MissingRuleParameterException( "Missing required {$feature} parameter for RandomPercentageRule" );
+        }
+
+        return new RandomPercentageRule(
+            self::_getRuleParam( 'percentage', $type, $params ),
+            $feature
+        );
+
       default:
         throw new UnknownRuleTypeException( 'Couldn\'t find rule of type "' . $type . '"' );
 
@@ -110,7 +122,7 @@ class RuleFactory {
    *
    * @return \DateTimeImmutable
    *
-   * @throws Behance\NBD\Gatekeeper\Exceptions\DateTimeImmutableException
+   * @throws \Behance\NBD\Gatekeeper\Exceptions\DateTimeImmutableException
    */
   private static function _getDateImmutableObject( $date_time ) {
 

--- a/src/Rules/RandomPercentageRule.php
+++ b/src/Rules/RandomPercentageRule.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Behance\NBD\Gatekeeper\Rules;
+
+use Behance\NBD\Gatekeeper\Exceptions\ParameterValidationException;
+
+class RandomPercentageRule extends PercentageRuleAbstract {
+
+  const RULE_NAME       = 'random_percentage';
+  const IDENTIFIER_TYPE = RuleAbstract::IDENTIFIER_ANONYMOUS;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function canAccess( array $identifiers = [] ) {
+
+    $identifiers[ self::IDENTIFIER_TYPE ] = $this->_getRandomIdentifier();
+
+    return parent::canAccess( $identifiers );
+
+  } // canAccess
+
+  /**
+   * @return int
+   */
+  protected function _getRandomIdentifier() {
+
+      return mt_rand( 1, 1000 );
+
+  } // _getRandomIdentifier
+
+} // RandomPercentageRule

--- a/tests/unit/RuleFactoryTest.php
+++ b/tests/unit/RuleFactoryTest.php
@@ -13,6 +13,7 @@ use Behance\NBD\Gatekeeper\Rules\BinaryRule;
 use Behance\NBD\Gatekeeper\Rules\EndTimeRule;
 use Behance\NBD\Gatekeeper\Rules\IdentifierRule;
 use Behance\NBD\Gatekeeper\Rules\PercentageRule;
+use Behance\NBD\Gatekeeper\Rules\RandomPercentageRule;
 use Behance\NBD\Gatekeeper\Rules\StartTimeRule;
 use Behance\NBD\Gatekeeper\Test\BaseTest;
 
@@ -418,5 +419,35 @@ class RuleFactoryTest extends BaseTest {
     );
 
   } // createAnonymousPercentageRuleParamMissingFail
+
+  /**
+   * @test
+   */
+  public function createRandomPercentageRuleSuccess() {
+
+    $rule = RuleFactory::create(
+        RandomPercentageRule::RULE_NAME,
+        [
+            'percentage' => 10,
+        ],
+        'feature'
+    );
+
+    $this->assertInstanceOf( RandomPercentageRule::class, $rule );
+
+  } // createRandomPercentageRuleSuccess
+
+  /**
+   * @test
+   */
+  public function createRandomPercentageRuleParamMissingFail() {
+
+    $this->expectException( MissingRuleParameterException::class );
+
+    RuleFactory::create(
+        RandomPercentageRule::RULE_NAME
+    );
+
+  } // createRandomPercentageRuleParamMissingFail
 
 } // RuleFactoryTest

--- a/tests/unit/Rules/RandomPercentageRuleTest.php
+++ b/tests/unit/Rules/RandomPercentageRuleTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Behance\NBD\Gatekeeper\Rules;
+
+use Behance\NBD\Gatekeeper\Test\BaseTest;
+
+class RandomPercentageRuleTest extends BaseTest {
+
+  /**
+   * @var \Behance\NBD\Gatekeeper\Rules\RuleInterface
+   */
+  private $_rule;
+
+  /**
+   * @test
+   */
+  public function canAccessTrue() {
+
+    $this->_getRule( 60, 'feature' );
+
+    // 2 calls to confirm a new random identifier is used each time
+    $this->_rule->expects( $this->exactly( 2 ) )
+      ->method( '_getRandomIdentifier' )
+      ->willReturnOnConsecutiveCalls( 50, 1 );
+
+    $this->assertTrue( $this->_rule->canAccess() );
+    $this->assertTrue( $this->_rule->canAccess() );
+
+  } // canAccessTrue
+
+  /**
+* @test
+*/
+  public function canAccessFalse() {
+
+    $this->_getRule( 60, 'feature' );
+
+    $this->_rule->expects( $this->once() )
+      ->method( '_getRandomIdentifier' )
+      ->willReturn( 4 );
+
+    $this->assertFalse( $this->_rule->canAccess() );
+
+  } // canAccessFalse
+
+  /**
+   * @test
+   */
+  public function invalidPercentage() {
+
+    $this->expectException( \InvalidArgumentException::class );
+
+    new RandomPercentageRule( 'invalid', 'feature' );
+
+  } // invalidPercentage
+
+  /**
+   * @test
+   */
+  public function invalidPercentageRange() {
+
+    $this->expectException( \InvalidArgumentException::class );
+
+    new RandomPercentageRule( 101, 'feature' );
+
+  } // invalidPercentageRange
+
+  /**
+   * @test
+   */
+  public function invalidPercentageNull() {
+
+    $this->expectException( \InvalidArgumentException::class );
+
+    new RandomPercentageRule( null, 'feature' );
+
+  } // invalidPercentageNull
+
+  /**
+   * @param int    $percentage
+   * @param string $feature
+   */
+  private function _getRule( $percentage, $feature ) {
+
+    $this->_rule = new RandomPercentageRule( $percentage, $feature );
+
+    $this->_rule = $this->getMock( RandomPercentageRule::class, [ '_getRandomIdentifier' ], [ $percentage, $feature ] );
+
+  } // _getRule
+
+} // RandomPercentageRuleTest


### PR DESCRIPTION
@ingluisjimenez 
@markdunphy 
@be-dmitry  

Adding this because the use-case came up for @markdunphy and myself where we want to grant access for simple percentage based testing/load testing but there's no request or identifier present and random is fine.