### PR TITLE
Identifier Validation: Remove _validateIdentifiers

### DIFF
--- a/src/Rules/IdentifierRule.php
+++ b/src/Rules/IdentifierRule.php
@@ -44,8 +44,6 @@ class IdentifierRule extends RuleAbstract {
    */
   public function canAccess( array $identifiers = [] ) {
 
-    $this->_validateIdentifiers( $identifiers );
-
     $valid_identifiers = $this->_getIdentifierMap();
 
     return

--- a/src/Rules/IpRangeRule.php
+++ b/src/Rules/IpRangeRule.php
@@ -41,8 +41,6 @@ class IpRangeRule extends RuleAbstract {
    */
   public function canAccess( array $identifiers = [] ) {
 
-    $this->_validateIdentifiers( $identifiers );
-
     if ( !isset( $identifiers[ RuleAbstract::IDENTIFIER_IP ] ) ) {
       return false;
     }

--- a/src/Rules/PercentageRuleAbstract.php
+++ b/src/Rules/PercentageRuleAbstract.php
@@ -40,8 +40,6 @@ abstract class PercentageRuleAbstract extends RuleAbstract {
    */
   public function canAccess( array $identifiers = [] ) {
 
-    $this->_validateIdentifiers( $identifiers );
-
     return
         isset( $identifiers[ static::IDENTIFIER_TYPE ] )
         && $this->_getBucket( $identifiers[ static::IDENTIFIER_TYPE ] ) <= $this->_percentage;

--- a/src/Rules/RuleAbstract.php
+++ b/src/Rules/RuleAbstract.php
@@ -11,13 +11,6 @@ abstract class RuleAbstract implements RuleInterface {
   const IDENTIFIER_TIME          = 'time';
   const IDENTIFIER_IP            = 'ip';
 
-  const IDENTIFIER_TYPES = [
-      self::IDENTIFIER_AUTHENTICATED,
-      self::IDENTIFIER_ANONYMOUS,
-      self::IDENTIFIER_TIME,
-      self::IDENTIFIER_IP,
-  ];
-
   /**
    * @return string
    */
@@ -26,19 +19,5 @@ abstract class RuleAbstract implements RuleInterface {
     return static::RULE_NAME;
 
   } // getType
-
-  /**
-   * @param  array $identifiers
-   * @throws \Behance\NBD\Gatekeeper\Exceptions\InvalidIdentifierException
-   */
-  protected function _validateIdentifiers( array $identifiers ) {
-
-    foreach ( $identifiers as $identifier_type => $identifier_value ) {
-      if ( !in_array( $identifier_type, self::IDENTIFIER_TYPES ) ) {
-        throw new InvalidIdentifierException( 'Identifier with invalid type "' . $identifier_type . '" supplied.' );
-      }
-    }
-
-  } // _validateIdentifiers
 
 } // RuleAbstract

--- a/tests/unit/Rules/AnonymousPercentageRuleTest.php
+++ b/tests/unit/Rules/AnonymousPercentageRuleTest.php
@@ -54,7 +54,6 @@ class AnonymousPercentageRuleTest extends BaseTest {
 
     $this->_getRule( 60, 'feature' );
 
-    $this->expectException( InvalidIdentifierException::class );
     $this->assertFalse( $this->_rule->canAccess( [ 'balhblah' => '4' ] ) );
 
   } // canAccessBadIdentifier

--- a/tests/unit/Rules/AuthenticatedPercentageRuleTest.php
+++ b/tests/unit/Rules/AuthenticatedPercentageRuleTest.php
@@ -54,7 +54,6 @@ class AuthenticatedPercentageRuleTest extends BaseTest {
 
     $this->_getRule( 60, 'feature' );
 
-    $this->expectException( InvalidIdentifierException::class );
     $this->assertFalse( $this->_rule->canAccess( [ 'balhblah' => '4' ] ) );
 
   } // canAccessBadIdentifier


### PR DESCRIPTION
Remove _validateIdentifiers since the rule should check for the identifiers it is expecting instead of relying on abstract to know every identifier. 

@ingluisjimenez 
@DFoxinator 